### PR TITLE
Fixed bug with large file viewing

### DIFF
--- a/qhexeditprivate.h
+++ b/qhexeditprivate.h
@@ -139,7 +139,7 @@ class QHexEditPrivate : public QWidget
         qint64 _lastvscrollpos;
         int _whellscrolllines;
         int _cursorX;
-        int _cursorY;
+        qint64 _cursorY;
         int _addressWidth;
         int _xposascii;
         int _xposhex;


### PR DESCRIPTION
When viewing a very large file (many gigabytes of data), setCursorPos
calls sometimes fail to ensure that the cursor is visible due to
overflows in the _cursorY variable.  Increasing _cursorY to a 64-bit int
fixes the problem.
