### PR TITLE
Include required STL header

### DIFF
--- a/document/gapbuffer.h
+++ b/document/gapbuffer.h
@@ -1,6 +1,8 @@
 #ifndef GAPBUFFER_H
 #define GAPBUFFER_H
 
+#include <cstdint>
+
 #include <QByteArray>
 #include <QIODevice>
 


### PR DESCRIPTION
Fix problems compiling because of missing definitions from `<cstdint>` or `<stdint.h>` for `int64_t` and `uint64_t`. This change will allow this header to compile, regardless of how/where QHexEdit is included in a project (previously would only work if dependent header was included prior).