### PR TITLE
Overwrite mode

### DIFF
--- a/document/qhexcursor.cpp
+++ b/document/qhexcursor.cpp
@@ -181,6 +181,15 @@ void QHexCursor::setSelectedPart(QHexCursor::SelectedPart sp)
     emit selectedPartChanged();
 }
 
+void QHexCursor::setInsertionMode(QHexCursor::InsertionMode mode)
+{
+	bool differentmode = (this->_insertionmode != mode);
+	this->_insertionmode = mode;
+
+	if (differentmode)
+		emit insertionModeChanged();
+}
+
 void QHexCursor::clearSelection()
 {
     if(this->_selectionstart == this->_offset)

--- a/document/qhexcursor.h
+++ b/document/qhexcursor.h
@@ -43,6 +43,7 @@ class QHexCursor : public QObject
         void setSelection(integer_t startoffset, integer_t endoffset);
         void setSelectionRange(integer_t startoffset, integer_t length);
         void setSelectedPart(SelectedPart sp);
+        void setInsertionMode(InsertionMode mode);
         void clearSelection();
         bool removeSelection();
         void moveOffset(sinteger_t c, bool bynibble = false);

--- a/qhexedit.cpp
+++ b/qhexedit.cpp
@@ -39,6 +39,16 @@ QHexMetrics *QHexEdit::metrics() const
     return this->_hexedit_p->metrics();
 }
 
+bool QHexEdit::overwriteOnly() const
+{
+    return this->_hexedit_p->overwriteOnly();
+}
+
+void QHexEdit::setOverwriteOnly(bool b)
+{
+    this->_hexedit_p->setOverwriteOnly(b);
+}
+
 bool QHexEdit::readOnly() const
 {
     return this->_hexedit_p->readOnly();

--- a/qhexedit.h
+++ b/qhexedit.h
@@ -17,9 +17,11 @@ class QHexEdit : public QFrame
         explicit QHexEdit(QWidget *parent = 0);
         QHexDocument *document() const;
         QHexMetrics *metrics() const;
+        bool overwriteOnly() const;
         bool readOnly() const;
 
     public slots:
+        void setOverwriteOnly(bool b);
         void setReadOnly(bool b);
         void setDocument(QHexDocument *document);
         void scroll(QWheelEvent *event);

--- a/qhexeditprivate.cpp
+++ b/qhexeditprivate.cpp
@@ -14,6 +14,7 @@ QHexEditPrivate::QHexEditPrivate(QScrollArea *scrollarea, QScrollBar *vscrollbar
 
     this->_scrollarea = scrollarea;
     this->_vscrollbar = vscrollbar;
+    this->_overwriteonly = false;
     this->_readonly = false;
 
     connect(this->_vscrollbar, &QScrollBar::valueChanged, [this] { this->update(); });
@@ -34,6 +35,11 @@ QHexDocument *QHexEditPrivate::document() const
 QHexMetrics *QHexEditPrivate::metrics() const
 {
     return this->_metrics;
+}
+
+bool QHexEditPrivate::overwriteOnly() const
+{
+    return this->_overwriteonly;
 }
 
 bool QHexEditPrivate::readOnly() const
@@ -78,6 +84,17 @@ void QHexEditPrivate::setDocument(QHexDocument *document)
     });
 
     this->update();
+}
+
+void QHexEditPrivate::setOverwriteOnly(bool b)
+{
+    this->_overwriteonly = b;
+    if (b && this->_document != NULL)
+    {
+        QHexCursor* cursor = this->_document->cursor();
+        if (cursor != NULL)
+            cursor->setInsertionMode(QHexCursor::OverwriteMode);
+    }
 }
 
 void QHexEditPrivate::setReadOnly(bool b)
@@ -254,9 +271,12 @@ bool QHexEditPrivate::processInsOvrEvents(QKeyEvent *event)
 {
     if((event->key() == Qt::Key_Insert) && (event->modifiers() == Qt::NoModifier))
     {
-        QHexCursor* cursor = this->_document->cursor();
-        cursor->switchMode();
-        cursor->blink(true);
+        if (!this->_overwriteonly)
+        {
+            QHexCursor* cursor = this->_document->cursor();
+            cursor->switchMode();
+            cursor->blink(true);
+        }
         return true;
     }
 

--- a/qhexeditprivate.cpp
+++ b/qhexeditprivate.cpp
@@ -146,7 +146,8 @@ void QHexEditPrivate::processHexPart(int key)
         return;
     }
 
-    if((cursor->isOverwriteMode() && !this->_document->isEmpty()) || cursor->nibbleIndex()) // Override mode, or update low nibble
+    if((cursor->isOverwriteMode() || cursor->nibbleIndex()) // Override mode, or update low nibble
+        && cursor->offset() < this->_document->length())
     {
         uchar hexval = this->_document->at(cursor->offset());
 

--- a/qhexeditprivate.h
+++ b/qhexeditprivate.h
@@ -17,8 +17,10 @@ class QHexEditPrivate : public QWidget
         explicit QHexEditPrivate(QScrollArea* scrollarea, QScrollBar* vscrollbar, QWidget *parent = 0);
         QHexDocument* document() const;
         QHexMetrics* metrics() const;
+        bool overwriteOnly() const;
         bool readOnly() const;
         void setDocument(QHexDocument* document);
+        void setOverwriteOnly(bool b);
         void setReadOnly(bool b);
         void scroll(QWheelEvent *event);
 
@@ -56,6 +58,7 @@ class QHexEditPrivate : public QWidget
         QHexDocument* _document;
         QHexMetrics* _metrics;
         QHexTheme* _theme;
+        bool _overwriteonly;
         bool _readonly;
 };
 


### PR DESCRIPTION
1. Fix uncapturable exception throw when writing beyond the document in overwrite mode. Cursor position will be checked against document length and overwrite operation won't happen if cursor position is beyond the length.
2. Add boolean "overwriteonly" flag to only allow the overwrite mode. Insert key will do nothing.