### PR TITLE
Fix ba when its size is 0,  it crashes with QByteArray hex(-1, Qt::Un…

### DIFF
--- a/model/qhexutils.cpp
+++ b/model/qhexutils.cpp
@@ -245,6 +245,11 @@ QByteArray variantToByteArray(QVariant value, QHexFindMode mode, unsigned int op
 
 QByteArray toHex(const QByteArray& ba, char sep)
 {
+    if (ba.isEmpty())
+    {
+        return QByteArray();
+    }
+	
     QByteArray hex(sep ? (ba.size() * 3 - 1) : (ba.size() * 2), Qt::Uninitialized);
 
     for(auto i = 0, o = 0; i < ba.size(); i++)


### PR DESCRIPTION
When I copy 0 items, it leads to a crash.
void QHexView::copy(bool hex) const
{
···
    if(hex) bytes = QHexUtils::toHex(bytes, ' ').toUpper();
···
}
QByteArray hex(sep ? (ba.size() * 3 - 1) : (ba.size() * 2), Qt::Uninitialized);
(sep ? (ba.size() * 3 - 1) : (ba.size() * 2)  == -1
QByteArray crashes